### PR TITLE
Refactor hosts and ids

### DIFF
--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -27,7 +27,7 @@
 {%- set real_config_src  = real_home + '/conf' %}
 {%- set real_config_dist = alt_config + '.dist' %}
 
-{%- set force_mine_update = salt['mine.send']('roles:zookeeper', 'network.get_hostname') %}
+{%- set force_mine_update = salt['mine.send']('network.get_hostname') %}
 {%- set zookeepers_host_dict = salt['mine.get']('roles:zookeeper', 'network.get_hostname', 'grain') %}
 {%- set zookeepers_ids = zookeepers_host_dict.keys() %}
 {%- set zookeepers_hosts = zookeepers_host_dict.values() %}


### PR DESCRIPTION
Hi, first of all thank you for doing this formula it helped me a lot to set up a zookeeper cluster easily.

Not sure if i did something wrong but I found some issues in the `settings.sls` file
and therefore in the zookeeper conf files that are generated.

Mainly I changed the `zookeepers_host_list` to a `zookeepers_host_dict` using the
mine `network.get_hostname values()` (ip address) instead of 
`network.intefaces keys()` (minion id) since the generated `zoo.conf` was being like:

```
server.1=minion-id-1:2888:3888
server.2=minion-id-2:2888:3888
server.3=minion-id-3:2888:3888
```

now it is:

```
server.1=instance-hostname-1:2888:3888
server.2=instance-hostname-2:2888:3888
server.3=instance-hostname-3:2888:3888
```

Finally i forced the mine to send the network information to the minions
by doing `{%- set force_mine_update = salt['mine.send']('network.get_hostname') %}`

With those changes i was able to create 3 instances via salt-clou using a provider like this:

```
zookeeper:
  provider: ec2

  grains:
    roles:
      - zookeeper
```

And then just bootstrap them using: `sudo salt 'zoo*' state.sls zookeeper.server`
