### PR TITLE
use prefix for curl

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -4,7 +4,7 @@ java_home: /usr/java/default
 zookeeper:
     source_url: 'http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz'
     version: 3.4.6
-    prefix: /usr/lib/zookeeper
+    prefix: /usr/lib
     uid: 6030
     config:
       data_dir: /var/lib/zookeeper/data

--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -21,7 +21,7 @@ zk-directories:
 install-zookeeper-dist:
   cmd.run:
     - name: curl -L '{{ zk.source_url }}' | tar xz
-    - cwd: /usr/lib
+    - cwd: {{ zk.prefix }}
     - unless: test -d {{ zk.real_home }}/lib
   alternatives.install:
     - name: zookeeper-home-link

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -7,7 +7,7 @@
 # these are global - hence pillar-only
 {%- set uid          = p.get('uid', '6030') %}
 {%- set userhome     = p.get('userhome', '/home/zookeeper') %}
-{%- set prefix       = p.get('prefix', '/usr/lib/zookeeper') %}
+{%- set prefix       = p.get('prefix', '/usr/lib') %}
 {%- set java_home    = salt['pillar.get']('java_home', '/usr/lib/java') %}
 
 {%- set version           = g.get('version', p.get('version', '3.4.6')) %}
@@ -42,7 +42,7 @@
 
 {%- set alt_config   = salt['grains.get']('zookeeper:config:directory', '/etc/zookeeper/conf') %}
 {%- set real_config  = alt_config + '-' + version %}
-{%- set alt_home     = prefix %}
+{%- set alt_home     = prefix + '/zookeeper' %}
 {%- set real_home    = alt_home + '-' + version %}
 {%- set real_config_src  = real_home + '/conf' %}
 {%- set real_config_dist = alt_config + '.dist' %}


### PR DESCRIPTION
Right now this formula always installs to /usr/lib/zookeeper-3.4.6. This PR makes it configurable via prefix.
