### PR TITLE
Allow to configure custom Mine function to get cluster node addresses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea
-
+# VIM editor swap files
+.*.sw?
+# Backups
+*~
+*.bak

--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ Installs the server configuration and enables and starts the zookeeper service.
 Only works if 'zookeeper' is one of the roles (grains) of the node. This separation
 allows for nodes to have the zookeeper libs and environment available without running the service.
 
-Zookeeper Role and Connection String
-====================================
+Zookeeper Role and Client Connection String
+===========================================
 
 The implementation depends on the existence of the ``roles`` grain in your minion configuration -
 at least one minion in your network has to have the **zookeeper role** which means that it is a
@@ -48,32 +48,30 @@ the result of calling:
 
 .. code:: yaml
 
-    {%- from 'zookeeper/settings.sls' import zk with context %}
+   {%- from 'zookeeper/settings.sls' import zk with context -%}
 
-    /etc/somefile.conf:
-      file.managed:
-        - source: salt://some-formula/files/something.xml
-        - user: root
-        - group: root
-        - mode: 644
-        - template: jinja
-        - context:
-          zookeepers: {{ zk.connection_string }}
+   /etc/somefile.conf:
+     file.managed:
+       - source: salt://some-formula/files/something.xml
+       - user: root
+       - group: root
+       - mode: 644
+       - template: jinja
+       - context:
+         zookeepers: {{ zk.connection_string }}
 
 ``zk.connection_string`` variable contains a string that reflects the names and ports of the hosts
 with the ``zookeeper`` role in the cluster, like
 
-.. code:: yaml
+::
 
-    host1.mycluster.net:2181,host2.mycluster.net:2181,host3.mycluster.net:2181
+  host1.mycluster.net:2181,host2.mycluster.net:2181,host3.mycluster.net:2181
 
 And this will also work for single-node configurations. Whenever you have more than 2 hosts with
 the ``zookeeper`` role the formula will setup a Zookeeper cluster, whenever there is an even number
 it will be (number - 1).
 
-
 .. _`Salt Mine`: https://docs.saltstack.com/en/latest/topics/mine/index.html
-
 
 Customisations in Pillar or Grains
 ----------------------------------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 zookeeper
 =========
 
-Formula to set up and configure a single-node zookeeper server.
+Formula to set up and configure a single-node Zookeeper server or multi-node Zookeeper cluster.
 
 .. note::
 
@@ -14,7 +14,7 @@ Formula Dependencies
 
 * sun-java
 
-Available states
+Available States
 ================
 
 .. contents::
@@ -23,7 +23,8 @@ Available states
 ``zookeeper``
 -------------
 
-Downloads the zookeeper tarball from zookeeper:source_url (either pillar or grain), installs the package.
+Downloads the zookeeper tarball from ``zookeeper:source_url`` (either Pillar or Grain), installs
+the package.
 
 ``zookeeper.server``
 --------------------
@@ -32,24 +33,20 @@ Installs the server configuration and enables and starts the zookeeper service.
 Only works if 'zookeeper' is one of the roles (grains) of the node. This separation
 allows for nodes to have the zookeeper libs and environment available without running the service.
 
-Zookeeper role and Salt Minion Configuration
-============================================
+Zookeeper Role and Connection String
+====================================
 
-The implementation depends on the existence of the _roles_ grain in your minion configuration - at least
-one minion in your network has to have the *zookeeper* role which means that it is a zookeeper server. 
+The implementation depends on the existence of the ``roles`` grain in your minion configuration -
+at least one minion in your network has to have the **zookeeper role** which means that it is a
+Zookeeper server.
 
-For this to work it is necessary to setup salt mine like below in /etc/salt/minion.d/mine_functions.conf:
+The formula gathers Zookeeper node addresses using `Salt Mine`_ by publishing the Minion host name
+via ``network.get_hostname`` function to the Salt Master (this is a default behaviour).
 
-::
+This will allow you to use the ``zookeeper.settings`` state in other states to configure clients -
+the result of calling:
 
-    mine_functions:
-      network.get_hostname: []
-      grains.items: []
-
-
-This will allow you to use the zookeeper.settings state in other states to configure clients - the result of calling
-
-::
+.. code:: yaml
 
     {%- from 'zookeeper/settings.sls' import zk with context %}
 
@@ -63,12 +60,58 @@ This will allow you to use the zookeeper.settings state in other states to confi
         - context:
           zookeepers: {{ zk.connection_string }}
 
-is a string that reflects the names and ports of the hosts with the zookeeper role in the cluster, like
+``zk.connection_string`` variable contains a string that reflects the names and ports of the hosts
+with the ``zookeeper`` role in the cluster, like
 
-::
+.. code:: yaml
 
     host1.mycluster.net:2181,host2.mycluster.net:2181,host3.mycluster.net:2181
 
-and this will also work for single-node configurations. Whenever you have more than 2 hosts with the zookeeper role the formula will setup
-a zookeeper cluster, whenever there is an even number it will be (number - 1).
+And this will also work for single-node configurations. Whenever you have more than 2 hosts with
+the ``zookeeper`` role the formula will setup a Zookeeper cluster, whenever there is an even number
+it will be (number - 1).
 
+
+.. _`Salt Mine`: https://docs.saltstack.com/en/latest/topics/mine/index.html
+
+
+Customisations in Pillar or Grains
+----------------------------------
+
+hosts_function
+~~~~~~~~~~~~~~
+
+It is possible to extract other data than Minions hostname, such as IP addresses, to provision a
+cluster and produce the connection string for configuring clients.
+
+For example, to setup a cluster working on second network interface create following Pillar SLS
+file:
+
+.. code:: yaml
+
+   # pillar/zookeeper/init.sls
+
+   mine_functions:
+     network.ip_addrs:
+       interface: eth1
+
+   # This also could be configured in the Grains for a Minion
+   zookeeper:
+     hosts_function: network.ip_addrs
+
+And apply this SLS to your Zookeeper cluster in the Pillar ``top.sls`` file:
+
+.. code:: yaml
+
+   # pillar/top.sls
+
+   base:
+     'roles:zookeeper':
+       - match: grain
+       - zookeeper
+
+After this, ``zoo.cfg`` file and client connection string will contain the *first* IP address
+assigned to ``eth1`` network interface for each node in the cluster.
+
+
+.. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/pillar.example
+++ b/pillar.example
@@ -1,33 +1,41 @@
-# these are the supported pillars with their defaults
+# These are the supported Pillars with their defaults
 
-java_home: /usr/java/default
+java_home: /usr/lib/java
 zookeeper:
-    source_url: 'http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz'
-    version: 3.4.6
-    prefix: /usr/lib
-    uid: 6030
-    targeting_method: grain # [compound, glob] also supported
-    config:
-      data_dir: /var/lib/zookeeper/data
-      port: 2181
-      jmx_port: 2183
-      snap_count: None
-      snap_retain_count: 3
-      purge_interval: None
-      max_client_cnxns: None
-      max_perm_size: 128
-      max_heap_size: 1024
-      initial_heap_size: 256
-      jvm_opts: None
-      log_level: INFO
+  source_url: 'http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz'
+  version: 3.4.6
+  prefix: /usr/lib
+  uid: 6030
+  hosts_target: 'roles:zookeeper'
+  targeting_method: grain # [compound, glob] also supported
+  hosts_function: network.get_hostname
+  config:
+    data_dir: /var/lib/zookeeper/data
+    port: 2181
+    jmx_port: 2183
+    snap_count: None
+    snap_retain_count: 3
+    purge_interval: None
+    max_client_cnxns: None
+    max_perm_size: 128
+    max_heap_size: 1024
+    initial_heap_size: 256
+    jvm_opts: None
+    log_level: INFO
 
-mine_functions:
-  network.interfaces: []
-  test.ping: []
 
-# you can override everything in config: locally with grains, additionally there is support for
+# Configure Salt Mine function with parameters used in zookeeper:hosts_function
+#
+# mine_functions:
+#   network.ip_addrs:
+#     interface: eth0
+
+# You can override everything in config: locally with grains, additionally there is support for
 # the bind_address grain
 #
 # zookeeper:
 #   config:
-#     bind_address: /var/lib/zookeeper/data
+#     bind_address: 0.0.0.0
+
+
+# vim: filetype=yaml

--- a/pillar.example
+++ b/pillar.example
@@ -30,8 +30,8 @@ zookeeper:
 #   network.ip_addrs:
 #     interface: eth0
 
-# You can override everything in config: locally with grains, additionally there is support for
-# the bind_address grain
+# You can override everything in config: locally with grains, additionally
+# there is support for the bind_address grain
 #
 # zookeeper:
 #   config:

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -1,6 +1,6 @@
 {%- if 'zookeeper' in salt['grains.get']('roles', []) %}
 {%- from 'zookeeper/settings.sls' import zk with context %}
-{%- from "zookeeper/map.jinja" import zookeeper_map with context %}
+{%- from 'zookeeper/map.jinja' import zookeeper_map with context %}
 
 include:
   - zookeeper


### PR DESCRIPTION
This PR allows to provide any Salt module function to be used in Mine to get cluster node addresses from Minions, even `cmd.run`. Real life use case is described in README file (for multi-homed machines).
By default the formula utilizes `network.get_hostname` Mine function as it was before.
Also, README was updated about no need to define Mine function explicitly. This should resolve issue #16.

Thanks.