### PR TITLE
Explain and improve Zookeeper nodes targeting for client connection string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ Target only some of Minions with particular Grain using `Compound matcher`_:
 .. _`Salt Mine`: https://docs.saltstack.com/en/latest/topics/mine/index.html
 .. _`Grain targeting`: https://docs.saltstack.com/en/latest/topics/targeting/grains.html
 .. _`Glob targeting`: https://docs.saltstack.com/en/latest/topics/targeting/globbing.html#globbing
-.. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/grains.html
+.. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/compound.html
 
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Formula Dependencies
 
 * sun-java
 
-Available States
+Available states
 ================
 
 .. contents::
@@ -37,8 +37,14 @@ Zookeeper Role and Client Connection String
 ===========================================
 
 The implementation depends on the existence of the ``roles`` grain in your minion configuration -
-at least one minion in your network has to have the **zookeeper role** which means that it is a
+at least one minion in your network has to have the **zookeeper** role which means that it is a
 Zookeeper server.
+
+You could assign the role with following command executed from your Master:
+
+.. code:: console
+
+  salt 'zk-node*' grains.append roles zookeeper
 
 The formula gathers Zookeeper node addresses using `Salt Mine`_ by publishing the Minion host name
 via ``network.get_hostname`` function to the Salt Master (this is a default behaviour).
@@ -48,17 +54,17 @@ the result of calling:
 
 .. code:: yaml
 
-   {%- from 'zookeeper/settings.sls' import zk with context -%}
+  {%- from 'zookeeper/settings.sls' import zk with context -%}
 
-   /etc/somefile.conf:
-     file.managed:
-       - source: salt://some-formula/files/something.xml
-       - user: root
-       - group: root
-       - mode: 644
-       - template: jinja
-       - context:
-         zookeepers: {{ zk.connection_string }}
+  /etc/somefile.conf:
+   file.managed:
+     - source: salt://some-formula/files/something.xml
+     - user: root
+     - group: root
+     - mode: 644
+     - template: jinja
+     - context:
+       zookeepers: {{ zk.connection_string }}
 
 ``zk.connection_string`` variable contains a string that reflects the names and ports of the hosts
 with the ``zookeeper`` role in the cluster, like
@@ -71,13 +77,17 @@ And this will also work for single-node configurations. Whenever you have more t
 the ``zookeeper`` role the formula will setup a Zookeeper cluster, whenever there is an even number
 it will be (number - 1).
 
-.. _`Salt Mine`: https://docs.saltstack.com/en/latest/topics/mine/index.html
+.. note::
+
+  Standalone Zookeeper server would be installed and configured by explicitly applying
+  ``zookeeper.server`` state to the Minion without any roles assigned. But in this case the server
+  will not appear in ``connection_string`` variable from ``zookeeper/settings.sls``.
 
 Customisations in Pillar or Grains
 ----------------------------------
 
-hosts_function
-~~~~~~~~~~~~~~
+``hosts_function``
+~~~~~~~~~~~~~~~~~~
 
 It is possible to extract other data than Minions hostname, such as IP addresses, to provision a
 cluster and produce the connection string for configuring clients.
@@ -87,29 +97,77 @@ file:
 
 .. code:: yaml
 
-   # pillar/zookeeper/init.sls
+  # pillar/zookeeper/init.sls
 
-   mine_functions:
-     network.ip_addrs:
-       interface: eth1
+  mine_functions:
+   network.ip_addrs:
+     interface: eth1
 
-   # This also could be configured in the Grains for a Minion
-   zookeeper:
-     hosts_function: network.ip_addrs
+  # This also could be configured in the Grains for a Minion
+  zookeeper:
+    hosts_function: network.ip_addrs
 
 And apply this SLS to your Zookeeper cluster in the Pillar ``top.sls`` file:
 
 .. code:: yaml
 
-   # pillar/top.sls
+  # pillar/top.sls
 
-   base:
-     'roles:zookeeper':
-       - match: grain
-       - zookeeper
+  base:
+   'roles:zookeeper':
+     - match: grain
+     - zookeeper
 
 After this, ``zoo.cfg`` file and client connection string will contain the *first* IP address
 assigned to ``eth1`` network interface for each node in the cluster.
+
+``hosts_target``
+~~~~~~~~~~~~~~~~
+
+This key used in conjunction with the one below, ``targeting_method``. It defines how Salt Master
+recognize certain Minions as Zookeeper cluster members. By default, `Grain targeting`_ implied to
+get all nodes with ``roles:zookeeper`` value set. Any other Grain or even pattern could be used
+here. It is very useful if you have multiple independent clusters operating in your environment
+provisioned by single Salt Master.
+
+See examples in the next section for the details.
+
+``targeting_method``
+~~~~~~~~~~~~~~~~~~~~
+
+Set matching type for ``hosts_target`` key. Supported values are: ``grain`` (default), ``glob``
+and ``compound``.
+
+**Examples**:
+
+`Grain targeting`_ for *myapp* cluster by ``node_type``:
+
+.. code:: yaml
+
+  # pillar/zookeeper/init.sls
+  zookeeper:
+    hosts_target: node_type:myapp_zk
+
+Simple `Glob targeting`_ by Minion ID:
+
+.. code:: yaml
+
+  zookeeper:
+    hosts_target: zk-node*
+    targeting_method: glob
+
+Target only some of Minions with particular Grain using `Compound matcher`_:
+
+.. code:: yaml
+
+  zookeeper:
+    hosts_target: mycluster-node* and G@zookeeper:*
+    targeting_method: compound
+
+.. _`Salt Mine`: https://docs.saltstack.com/en/latest/topics/mine/index.html
+.. _`Grain targeting`: https://docs.saltstack.com/en/latest/topics/targeting/grains.html
+.. _`Glob targeting`: https://docs.saltstack.com/en/latest/topics/targeting/globbing.html#globbing
+.. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/grains.html
 
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/pillar.example
+++ b/pillar.example
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# vim: filetype=yaml
+
 # These are the supported Pillars with their defaults
 
 java_home: /usr/lib/java
@@ -6,9 +9,9 @@ zookeeper:
   version: 3.4.6
   prefix: /usr/lib
   uid: 6030
+  hosts_function: network.get_hostname
   hosts_target: 'roles:zookeeper'
   targeting_method: grain # [compound, glob] also supported
-  hosts_function: network.get_hostname
   config:
     data_dir: /var/lib/zookeeper/data
     port: 2181
@@ -36,6 +39,3 @@ zookeeper:
 # zookeeper:
 #   config:
 #     bind_address: 0.0.0.0
-
-
-# vim: filetype=yaml

--- a/zookeeper/conf/zoo.cfg
+++ b/zookeeper/conf/zoo.cfg
@@ -39,11 +39,15 @@ autopurge.purgeInterval={{ purge_interval }}
 maxClientCnxns={{ max_client_cnxns }}
 {%- endif %}
 
-{% if zookeepers|length() == 1 %}
+{% if zookeepers | length() == 1 -%}
+
 clientPortAddress={{ bind_address }}
+
 {%- else %}
+
 {%- for garbage_string in zookeepers %}
-{%- set myid, mynodename = garbage_string.split('+') %}
+  {%- set myid, mynodename = garbage_string.split('+') %}
 server.{{ myid }}={{ mynodename }}:2888:3888
 {%- endfor %}
+
 {%- endif %}

--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -1,4 +1,4 @@
-{%- from 'zookeeper/settings.sls' import zk with context %}
+{%- from 'zookeeper/settings.sls' import zk with context -%}
 
 zookeeper:
   group.present:
@@ -31,4 +31,3 @@ install-zookeeper-dist:
     - priority: 30
     - require:
       - cmd: install-zookeeper-dist
-

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -1,6 +1,5 @@
-{%- if 'zookeeper' in salt['grains.get']('roles', []) %}
-{%- from 'zookeeper/settings.sls' import zk with context %}
-{%- from 'zookeeper/map.jinja' import zookeeper_map with context %}
+{%- from 'zookeeper/map.jinja' import zookeeper_map with context -%}
+{%- from 'zookeeper/settings.sls' import zk with context -%}
 
 include:
   - zookeeper
@@ -53,7 +52,6 @@ zoo-cfg:
       max_client_cnxns: {{ zk.max_client_cnxns }}
       zookeepers: {{ zk.zookeepers_with_ids }}
 
-
 {{ zk.myid_path }}:
   file.managed:
     - user: zookeeper
@@ -78,6 +76,7 @@ zoo-cfg:
       log_level: {{ zk.log_level }}
 
 {%- if zookeeper_map.service_script %}
+
 {{ zookeeper_map.service_script }}:
   file.managed:
     - source: salt://zookeeper/conf/{{ zookeeper_map.service_script_source }}
@@ -96,5 +95,5 @@ zookeeper-service:
       - file: {{ zk.data_dir }}
     - watch:
       - file: zoo-cfg
-{%- endif %}
+
 {%- endif %}


### PR DESCRIPTION
This PR updates REAME with detailed explanation how to use alternative targeting methods other than ``zookeeper`` role in the Grains.
Also, for now having the role (or any other target) is not a hard requirement to just install standalone Zookeeper. And importing ``zookeeper/settings.sls`` without any nodes registered to the Master will not fail.

I believe it should fully resolve issue #15.
Thanks.