### PR TITLE
Use pillar value to control service restart on configuration change.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -169,5 +169,14 @@ Target only some of Minions with particular Grain using `Compound matcher`_:
 .. _`Glob targeting`: https://docs.saltstack.com/en/latest/topics/targeting/globbing.html#globbing
 .. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/compound.html
 
+``restart_on_config``
+~~~~~~~~~~~~~~~~~~~~~
+
+Restart the Zookeeper service on configuration change. It is recommended to set to True in a single server setup or when you initially deploy your emsemble. However, this is dangerous to allow to happen when deploying a configuration change to a running ensemble, as a rolling restart of each Zookeeper service is recommended.
+
+.. code:: yaml
+
+   zookeeper:
+     restart_on_config: True
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/pillar.example
+++ b/pillar.example
@@ -25,7 +25,7 @@ zookeeper:
     initial_heap_size: 256
     jvm_opts: None
     log_level: INFO
-
+  restart_on_config: True
 
 # Configure Salt Mine function with parameters used in zookeeper:hosts_function
 #

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -120,6 +120,7 @@ zoo-cfg:
 {%- endif %}
 {%- endif %}
 
+{% if zk.restart_on_change %}
 zookeeper-service:
   service.running:
     - name: zookeeper
@@ -128,3 +129,4 @@ zookeeper-service:
       - file: {{ zk.data_dir }}
     - watch:
       - file: zoo-cfg
+{% endif %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -15,6 +15,9 @@
 {%- set default_url       = 'http://apache.osuosl.org/zookeeper/' + version_name + '/' + version_name + '.tar.gz' %}
 {%- set source_url        = g.get('source_url', p.get('source_url', default_url)) %}
 
+# This tells the state whether or not to restart the service on configuration change
+{%- set restart_on_change = p.get('restart_on_config', 'True') %}
+
 # bind_address is only supported as a grain, because it has to be host-specific
 {%- set bind_address      = gc.get('bind_address', '0.0.0.0') %}
 


### PR DESCRIPTION
Having this set to false will allow us to bootstrap nodes and run highstates for configuration changes while allowing us to do a rolling restart outside of the highstate.