### PR TITLE
Various improvements

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -5,8 +5,10 @@
 
 java_home: /usr/lib/java
 zookeeper:
-  source_url: 'http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.6/zookeeper-3.4.6.tar.gz'
-  version: 3.4.6
+  source_url: 'http://www.us.apache.org/dist/zookeeper/zookeeper-3.4.9/zookeeper-3.4.9.tar.gz'
+  version: 3.4.9
+  # You can disable md5 checking if you know exactly what you are doing and set the following to an empty string.
+  source_md5: 3e8506075212c2d41030d874fcc9dcd2
   prefix: /usr/lib
   uid: 6030
   hosts_function: network.get_hostname

--- a/pillar.example
+++ b/pillar.example
@@ -25,6 +25,8 @@ zookeeper:
     initial_heap_size: 256
     jvm_opts: None
     log_level: INFO
+    quorum_port: 2888
+    election_port: 3888
   restart_on_config: True
 
 # Use external service management instead init or systemd.

--- a/zookeeper/conf/zoo.cfg
+++ b/zookeeper/conf/zoo.cfg
@@ -47,7 +47,7 @@ clientPortAddress={{ bind_address }}
 
 {%- for garbage_string in zookeepers %}
   {%- set myid, mynodename = garbage_string.split('+') %}
-server.{{ myid }}={{ mynodename }}:2888:3888
+server.{{ myid }}={{ mynodename }}:{{ quorum_port }}:{{ election_port }}
 {%- endfor %}
 
 {%- endif %}

--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -19,11 +19,19 @@ zk-directories:
       - /var/log/zookeeper
 
 install-zookeeper-dist:
+  file.managed:
+    - name: /usr/local/src/{{ zk.version_name }}.tar.gz
+    - source: {{ zk.source_url }}
+{% if zk.source_md5 != "" %}
+    - source_hash: md5={{ zk.source_md5 }}
+{% endif %}
   cmd.run:
-    - name: curl -L '{{ zk.source_url }}' | tar xz --no-same-owner
+    - name: tar xzf /usr/local/src/{{ zk.version_name }}.tar.gz --no-same-owner
     - cwd: {{ zk.prefix }}
     - unless: test -d {{ zk.real_home }}/lib
-    - user: root
+    - runas: root
+    - require:
+      - file: install-zookeeper-dist
   alternatives.install:
     - name: zookeeper-home-link
     - link: {{ zk.alt_home }}

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -44,6 +44,8 @@ zoo-cfg:
     - template: jinja
     - context:
       port: {{ zk.port }}
+      quorum_port: {{ zk.quorum_port }}
+      election_port: {{ zk.election_port }}
       bind_address: {{ zk.bind_address }}
       data_dir: {{ zk.data_dir }}
       snap_count: {{ zk.snap_count }}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -14,6 +14,14 @@
 {%- set version_name      = 'zookeeper-' + version %}
 {%- set default_url       = 'http://apache.osuosl.org/zookeeper/' + version_name + '/' + version_name + '.tar.gz' %}
 {%- set source_url        = g.get('source_url', p.get('source_url', default_url)) %}
+{%- set default_md5s = {
+  "3.4.6": "971c379ba65714fd25dc5fe8f14e9ad1",
+  "3.4.8": "6bdddcd5179e9c259ef2bf4be2158d18",
+  "3.4.9": "3e8506075212c2d41030d874fcc9dcd2"
+  }
+%}
+
+{%- set source_md5       = g.get('source_md5', default_md5s.get(version, '00000000000000000000000000000000')) %}
 
 # This tells the state whether or not to restart the service on configuration change
 {%- set restart_on_change = p.get('restart_on_config', 'True') %}
@@ -113,6 +121,7 @@
                     'version_name': version_name,
                     'userhome' : userhome,
                     'source_url': source_url,
+                    'source_md5': source_md5,
                     'myid': myid,
                     'prefix' : prefix,
                     'alt_config' : alt_config,

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -23,6 +23,8 @@
 
 {%- set data_dir          = gc.get('data_dir', pc.get('data_dir', '/var/lib/zookeeper/data')) %}
 {%- set port              = gc.get('port', pc.get('port', '2181')) %}
+{%- set quorum_port       = gc.get('quorum_port', pc.get('quorum_port', '2888')) %}
+{%- set election_port     = gc.get('election_port', pc.get('election_port', '3888')) %}
 {%- set jmx_port          = gc.get('jmx_port', pc.get('jmx_port', '2183')) %}
 {%- set snap_count        = gc.get('snap_count', pc.get('snap_count', None)) %}
 {%- set snap_retain_count = gc.get('snap_retain_count', pc.get('snap_retain_count', 3)) %}
@@ -121,6 +123,8 @@
                     'real_config_dist' : real_config_dist,
                     'java_home' : java_home,
                     'port': port,
+                    'quorum_port': quorum_port,
+                    'election_port': election_port,
                     'jmx_port': jmx_port,
                     'bind_address': bind_address,
                     'data_dir': data_dir,


### PR DESCRIPTION
This PR covers two changes:

1. Configure saltstack to verify the md5sum of the downloaded zookeeper tarball. This helps prove authenticity of the zookeeper artifact and improves security of using the formula.
2. Allow specification of quorum_port: this is helpful if you're running multiple zookeepers on the same host. I didn't end up needing it. I won't feel bad if that particular patch is not wanted.