### PR TITLE
Add support for external service supervision tool.

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -27,6 +27,10 @@ zookeeper:
     log_level: INFO
   restart_on_config: True
 
+# Use external service management instead init or systemd.
+# process_control_system: supervisor # You can use whatever you want not just Supervisord.
+# pcs_restart_command: 'supervisorctl restart zookeeper'
+
 # Configure Salt Mine function with parameters used in zookeeper:hosts_function
 #
 # mine_functions:

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -59,6 +59,18 @@ zoo-cfg:
     - contents: |
         {{ zk.myid }}
 
+{%- if zk.process_control_system is defined %}
+{%- if zk.restart_on_change %}
+zookeeper-in-supervisord:
+  cmd.run:
+    - name: "{{ zk.pcs_restart_command }}"
+    - require:
+      - pkg: {{ zk.process_control_system }}
+    - onchanges:
+       - file: {{ zk.real_config }}/zoo.cfg
+{% endif %}
+{%- else %}
+
 {%- if grains.get('systemd') %}
 {{ zk.real_config }}/zookeeper.env:
   file.managed:
@@ -129,4 +141,5 @@ zookeeper-service:
       - file: {{ zk.data_dir }}
     - watch:
       - file: zoo-cfg
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Zookeeper's philosophy is fail-fast, so it requires supervision. And official documentation recommends to use one: [Supervision](https://zookeeper.apache.org/doc/r3.3.2/zookeeperAdmin.html#sc_supervision).

So I added support to use whatever supervision tool (e.g. [supervisord](http://supervisord.org/) or [daemontools](http://cr.yp.to/daemontools.html) ... etc) by provide that tool name and restart command to be used to restart the service. And at the same time it respect "restart_on_change" option.