### PR TITLE
Fix starting with `systemd` when using custom `prefix` in Pillar

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Copyright (c) 2014 Salt Stack Formulas
+   Copyright (c) 2014-2017 Salt Stack Formulas
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -11,4 +11,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/pillar.example
+++ b/pillar.example
@@ -25,7 +25,7 @@ zookeeper:
     max_perm_size: 128
     max_heap_size: 1024
     initial_heap_size: 256
-    jvm_opts: None
+    jvm_opts: ''
     log_level: INFO
     quorum_port: 2888
     election_port: 3888

--- a/zookeeper/conf/zookeeper-env.sh
+++ b/zookeeper/conf/zookeeper-env.sh
@@ -1,8 +1,0 @@
-{%- if jvm_opts == 'None' -%}
-{%- set jvm_opts = "" -%}
-{%- endif -%}
-export ZOO_LOG4J_PROP={{ log_level }},ROLLINGFILE
-export ZOO_LOG_DIR=/var/log/zookeeper
-export ZOOPIDFILE=/var/run/zookeeper/zookeeper-server.pid
-export JAVA_HOME={{ java_home }}
-export SERVER_JVMFLAGS="-Xms{{ initial_heap_size }}m -Xmx{{ max_heap_size }}m -XX:MaxPermSize={{ max_perm_size }}m {{ jvm_opts }} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port={{ jmx_port }}"

--- a/zookeeper/conf/zookeeper.env
+++ b/zookeeper/conf/zookeeper.env
@@ -1,8 +1,0 @@
-{%- if jvm_opts == 'None' -%}
-{%- set jvm_opts = "" -%}
-{%- endif -%}
-ZOO_LOG4J_PROP={{ log_level }},ROLLINGFILE
-ZOO_LOG_DIR=/var/log/zookeeper
-ZOOPIDFILE=/var/run/zookeeper/zookeeper-server.pid
-JAVA_HOME={{ java_home }}
-SERVER_JVMFLAGS="-Xms{{ initial_heap_size }}m -Xmx{{ max_heap_size }}m -XX:MaxPermSize={{ max_perm_size }}m {{ jvm_opts }} -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port={{ jmx_port }}"

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -39,7 +39,7 @@
 {%- set purge_interval    = gc.get('purge_interval', pc.get('purge_interval', None)) %}
 {%- set max_client_cnxns  = gc.get('max_client_cnxns', pc.get('max_client_cnxns', None)) %}
 {%- set log_level         = gc.get('log_level', pc.get('log_level', 'INFO')) %}
-{%- set systemd_script    = pc.get('systemd_script', '/etc/systemd/system/zookeeper.service') %}
+{%- set systemd_unit      = pc.get('systemd_unit', '/etc/systemd/system/zookeeper.service') %}
 #
 # JVM options - just follow grains/pillar settings for now
 #
@@ -53,7 +53,7 @@
 {%- set max_perm_size        = gc.get('max_perm_size', pc.get('max_perm_size', 128)) %}
 {%- set max_heap_size        = gc.get('max_heap_size', pc.get('max_heap_size', 1024)) %}
 {%- set initial_heap_size    = gc.get('initial_heap_size', pc.get('initial_heap_size', 256)) %}
-{%- set jvm_opts             = gc.get('jvm_opts', pc.get('jvm_opts', None)) %}
+{%- set jvm_opts             = gc.get('jvm_opts', pc.get('jvm_opts', '')) %}
 
 {%- set alt_config           = salt['grains.get']('zookeeper:config:directory', '/etc/zookeeper/conf') %}
 {%- set real_config          = alt_config + '-' + version %}
@@ -150,6 +150,6 @@
                     'max_perm_size': max_perm_size,
                     'jvm_opts': jvm_opts,
                     'log_level': log_level,
-                    'systemd_script': systemd_script,
+                    'systemd_unit': systemd_unit,
                     'restart_on_change': restart_on_change,
                   } ) %}

--- a/zookeeper/templates/zookeeper-env.sh.j2
+++ b/zookeeper/templates/zookeeper-env.sh.j2
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+export ZOO_LOG4J_PROP="{{ log_level }},ROLLINGFILE"
+export ZOO_LOG_DIR=/var/log/zookeeper
+export ZOOPIDFILE=/var/run/zookeeper/zookeeper-server.pid
+export JAVA_HOME="{{ java_home }}"
+export SERVER_JVMFLAGS="-Xms{{ initial_heap_size }}m -Xmx{{ max_heap_size }}m -XX:MaxPermSize={{ max_perm_size }}m -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port={{ jmx_port }} {{ jvm_opts }}"

--- a/zookeeper/templates/zookeeper.service.j2
+++ b/zookeeper/templates/zookeeper.service.j2
@@ -6,8 +6,7 @@ After=network.target
 User=zookeeper
 Group=zookeeper
 SyslogIdentifier=zookeeper
-EnvironmentFile=/etc/zookeeper/conf/zookeeper.env
-ExecStart=/usr/lib/zookeeper/bin/zkServer.sh start-foreground
+ExecStart={{ alt_home }}/bin/zkServer.sh start-foreground
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Hi @gravyboat 

This PR fixes Zookeeper service working on `systemd`-enabled distro with custom Pillar settings such as:

``` yaml
zookeeper:
  prefix: /usr/local  # or /opt
```

The main problem was the `systemd` service unit file appeared to be a Jinja2 template, but there are hard coded paths. Also, there is no need to provision separate `zookeeper.env` file especially for `systemd`, because `zkServer.sh` will correctly find and source `zookeeper-env.sh` file from approprite location.

Minor fixes:
- simplified usage of `jvm_opts` variable, now it's empty string by default
- cover case when `java_home` would contain spaces
- manage `zookeeper` service in any case and set requisites, only try to restart it if `zk.restart_on_change == True`
