### PR TITLE
Add nodes parameter and improve small issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,14 @@ the package.
 --------------------
 
 Installs the server configuration and enables and starts the Zookeeper service. Only works if
-``zookeeper`` is one of the roles (set via Grains) of the node. This separation allows for nodes to
-have the Zookeeper libs and environment available without running the service.
+either ``zookeeper`` is one of the roles (set via Grains) of the node or the node is listed in 
+``zookeeper:nodes`` (in either Grains or Pillar). This separation allows for nodes to have the 
+Zookeeper libs and environment available without running the service.
+
+``zookeeper.uninstalled``
+--------------------
+
+Uninstalls the Zookeeper and disables and stops the Zookeeper service.
 
 Zookeeper Role and Client Connection String
 ===========================================
@@ -192,6 +198,49 @@ Target only some of Minions with particular Grain using `Compound matcher`_:
 .. _`Glob targeting`: https://docs.saltstack.com/en/latest/topics/targeting/globbing.html#globbing
 .. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/compound.html
 
+``nodes``
+~~~~~~~~~~~~~~~~~~~~
+
+If you want to provide your own list of zookeeper nodes you can use ``nodes`` parameter. In this 
+case targeting method will not be used.
+
+As a node identifier you can use hostname, IP address, fqdn, minion id.
+You cannot use an IP address of the proxy server which redirects requests to the zookeeper node.
+You can use hostname of the proxy server which redirects requests to the zookeeper node only if
+zookeeper node has the same hostname as the proxy does.
+
+**Examples**:
+
+IP addresses usage:
+
+.. code:: yaml
+
+  zookeeper:
+    nodes:
+      - 192.168.0.101
+      - 192.168.0.102
+      - 192.168.0.103
+
+Minion id usage:
+
+.. code:: yaml
+
+  zookeeper:
+    nodes:
+      - minion1
+      - minion2
+      - minion3
+
+Mixed usage (IP, minion id, fqdn):
+
+.. code:: yaml
+
+  zookeeper:
+    nodes:
+      - 192.168.0.101
+      - minion2
+      - zookeeper3.mysite.com
+      
 ``restart_on_config``
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/pillar.example
+++ b/pillar.example
@@ -47,3 +47,16 @@ zookeeper:
 # zookeeper:
 #   config:
 #     bind_address: 0.0.0.0
+
+# If you want to provide your own list of zookeeper nodes you can use zookeeper:nodes parameter. 
+# In this case targeting method will not be used.
+# As a node identifier you can use hostname, IP address, fqdn, minion id.
+# You cannot use an IP address of the proxy server which redirects requests to the zookeeper node. 
+# You can use hostname of the proxy server which redirects requests to the zookeeper node only if 
+# zookeeper node has the same hostname as the proxy does.
+#
+# zookeeper:
+#   nodes:
+#     - 192.168.0.101
+#     - minion2
+#     - zookeeper3.mysite.com

--- a/zookeeper/conf/zoo.cfg
+++ b/zookeeper/conf/zoo.cfg
@@ -45,9 +45,8 @@ clientPortAddress={{ bind_address }}
 
 {%- else %}
 
-{%- for garbage_string in zookeepers %}
-  {%- set myid, mynodename = garbage_string.split('+') %}
-server.{{ myid }}={{ mynodename }}:{{ quorum_port }}:{{ election_port }}
+{%- for node in zookeepers %}
+server.{{ node.id }}={{ node.address | safe }}:{{ quorum_port }}:{{ election_port }}
 {%- endfor %}
 
 {%- endif %}

--- a/zookeeper/conf/zoo.cfg
+++ b/zookeeper/conf/zoo.cfg
@@ -46,7 +46,7 @@ clientPortAddress={{ bind_address }}
 {%- else %}
 
 {%- for node in zookeepers %}
-server.{{ node.id }}={{ node.address | safe }}:{{ quorum_port }}:{{ election_port }}
+server.{{ node.id }}={{ node.address }}:{{ quorum_port }}:{{ election_port }}
 {%- endfor %}
 
 {%- endif %}

--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -27,17 +27,30 @@ install-zookeeper-dist:
 {%- else %}
     - skip_verify: True
 {%- endif %}
+    - unless: test -d {{ zk.real_home }}/lib
   cmd.run:
     - name: tar xzf /usr/local/src/{{ zk.version_name }}.tar.gz --no-same-owner
     - cwd: {{ zk.prefix }}
-    - unless: test -d {{ zk.real_home }}/lib
+    - unless: test -d {{ zk.real_home }}/lib || ! test -f /usr/local/src/{{ zk.version_name }}.tar.gz
     - runas: root
     - require:
       - file: install-zookeeper-dist
+      
+zookeeper-home-link:
   alternatives.install:
-    - name: zookeeper-home-link
     - link: {{ zk.alt_home }}
     - path: {{ zk.real_home }}
     - priority: 30
     - require:
       - cmd: install-zookeeper-dist
+  file.symlink:
+    - name: {{ zk.alt_home }}
+    - target: {{ zk.real_home }}
+    - require:
+      - alternatives: zookeeper-home-link
+      
+remove_zookeeper_tar:
+  file.absent:
+    - name: /usr/local/src/{{ zk.version_name }}.tar.gz
+    - require:
+      - install-zookeeper-dist

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -28,7 +28,12 @@ zookeeper-config-link:
     - link: {{ zk.alt_config }}
     - path: {{ zk.real_config }}
     - priority: 30
-
+  file.symlink:
+    - name: {{ zk.alt_config }}
+    - target: {{ zk.real_config }}
+    - require:
+      - alternatives: zookeeper-config-link
+      
 zookeeper-config-dir:
   file.symlink:
     - name: {{ zk.real_home }}/conf

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -67,34 +67,31 @@
 {%- set hosts_target         = g.get('hosts_target', p.get('hosts_target', 'roles:zookeeper')) %}
 {%- set targeting_method     = g.get('targeting_method', p.get('targeting_method', 'grain')) %}
 
-{%- set zookeepers_with_ids       = [] %}
-{%- set zookeepers       = [] %}
-{%- set myid_dist = [] %}
-{%- set minion_ips = salt['network.ip_addrs']() %}
-{%- set connection_string = [] %}
+{%- set zookeepers_with_ids = [] %}
+{%- set zookeepers          = [] %}
+{%- set myid_dist           = [] %}
+{%- set connection_string   = [] %}
+{%- set minion_ips          = salt['network.ip_addrs']() %}
 
 {% if p.get('nodes') %}
-  {%- set zookeeper_nodes       = p.get('nodes', []) %}
+  {%- set zookeeper_nodes   = p.get('nodes', []) %}
 {%- else %}
-  {%- set force_mine_update    = salt['mine.send'](hosts_function) %}
-  {%- set zookeeper_nodes = salt['mine.get'](hosts_target, hosts_function, targeting_method) %}
+  {%- set force_mine_update = salt['mine.send'](hosts_function) %}
+  {%- set zookeeper_nodes   = salt['mine.get'](hosts_target, hosts_function, targeting_method) %}
 {%- endif %}
 
 {%- for node in zookeeper_nodes %}
   {%- set node_id = loop.index %}
-  {%- set zookeeper_with_id = {"id": node_id, "address": node.encode('utf8')} %}
+  {%- set zookeeper_with_id = {"id": node_id, "address": node.encode('ascii')} %}
   {%- do zookeepers_with_ids.append(zookeeper_with_id)  %}
-  {%- do connection_string.append( node.encode('utf8') + ':' + port | string() ) %}
-  {%- do zookeepers.append( node.encode('utf8') ) %}
-  {%- if myid_dist|length == 0 %}
-    {%- if node == salt['network.get_hostname']() %}
-        {%- do myid_dist.append(node_id)  %}
-    {%- elif node == grains['id'] %}
-        {%- do myid_dist.append(node_id)  %}
-    {%- elif node == grains['fqdn'] %}
-        {%- do myid_dist.append(node_id)  %}
-    {%- elif node == grains['nodename'] %}
-        {%- do myid_dist.append(node_id)  %}
+  {%- do connection_string.append( node.encode('ascii') + ':' + port | string() ) %}
+  {%- do zookeepers.append( node.encode('ascii') ) %}
+  {%- if myid_dist|length == 0 %}    
+    {%- if node in (salt['network.get_hostname'](),
+                grains['id'],
+                grains['fqdn'],
+                grains['nodename']) %}
+      {%- do myid_dist.append(node_id)  %}
     {%- else %}
       {%- for minion_ip in minion_ips %}
         {%- if node == minion_ip %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -67,54 +67,50 @@
 {%- set hosts_target         = g.get('hosts_target', p.get('hosts_target', 'roles:zookeeper')) %}
 {%- set targeting_method     = g.get('targeting_method', p.get('targeting_method', 'grain')) %}
 
-{%- set force_mine_update    = salt['mine.send'](hosts_function) %}
-{%- set zookeepers_host_dict = salt['mine.get'](hosts_target, hosts_function, targeting_method) %}
-{%- set zookeepers_ids       = zookeepers_host_dict.keys() %}
-{%- set zookeepers_hosts     = zookeepers_host_dict.values() %}
+{%- set zookeepers_with_ids       = [] %}
+{%- set zookeepers       = [] %}
+{%- set myid_dist = [] %}
+{%- set minion_ips = salt['network.ip_addrs']() %}
+{%- set connection_string = [] %}
 
-{%- set zookeeper_host_num   = zookeepers_ids | length() %}
-
-{%- if zookeeper_host_num == 0
-    or zookeeper_host_num is odd %}
-  # 0 means Zookeeper nodes have not been found,
-  # for 1, 3, 5 ... nodes just return the list
-  {%- set node_count = zookeeper_host_num %}
-{%- elif zookeeper_host_num is even %}
-  # for 2, 4, 6 ... nodes return (n -1)
-  {%- set node_count = zookeeper_host_num - 1 %}
+{% if p.get('nodes') %}
+  {%- set zookeeper_nodes       = p.get('nodes', []) %}
+{%- else %}
+  {%- set force_mine_update    = salt['mine.send'](hosts_function) %}
+  {%- set zookeeper_nodes = salt['mine.get'](hosts_target, hosts_function, targeting_method) %}
 {%- endif %}
 
-# yes, this is not pretty, but produces sth like:
-# {'node1': '0+node1', 'node2': '1+node2', 'node3': '2+node2'}
-{%- set zookeepers_with_ids = {} %}
-{%- for i in range(node_count) %}
-  {%- if zookeepers_hosts[i] is string %}
-    # get plain value from Zookeeper hosts fetched by the Mine function
-    {%- set node_addr = zookeepers_hosts[i] %}
-  {%- elif zookeepers_hosts[i] is sequence %}
-    # if list provided, take the first value
-    {%- set node_addr = zookeepers_hosts[i] | first() %}
-  {%- else %}
-    # skip any other values including nested dicts
-    {%- set node_addr = '' %}
-  {%- endif %}
-
-  {%- if node_addr %}
-    {%- do zookeepers_with_ids.update({zookeepers_ids[i] : '{0:d}'.format(i) + '+' + node_addr })  %}
+{%- for node in zookeeper_nodes %}
+  {%- set node_id = loop.index %}
+  {%- set zookeeper_with_id = {"id": node_id, "address": node.encode('utf8')} %}
+  {%- do zookeepers_with_ids.append(zookeeper_with_id)  %}
+  {%- do connection_string.append( node.encode('utf8') + ':' + port | string() ) %}
+  {%- do zookeepers.append( node.encode('utf8') ) %}
+  {%- if myid_dist|length == 0 %}
+    {%- if node == salt['network.get_hostname']() %}
+        {%- do myid_dist.append(node_id)  %}
+    {%- elif node == grains['id'] %}
+        {%- do myid_dist.append(node_id)  %}
+    {%- elif node == grains['fqdn'] %}
+        {%- do myid_dist.append(node_id)  %}
+    {%- elif node == grains['nodename'] %}
+        {%- do myid_dist.append(node_id)  %}
+    {%- else %}
+      {%- for minion_ip in minion_ips %}
+        {%- if node == minion_ip %}
+          {%- do myid_dist.append(node_id)  %}
+          {% break %}
+        {%- endif %}
+      {%- endfor %}
+    {%- endif %}
   {%- endif %}
 {%- endfor %}
 
-# a plain list of hostnames
-{%- set zookeepers = zookeepers_with_ids.values() | sort() %}
-
-# produce the connection string, sth. like: 'host1:2181,host2:2181,host3:2181'
-{%- set connection_string = [] %}
-{%- for n in zookeepers %}
-  {%- do connection_string.append( n.split('+') | last() + ':' + port | string() ) %}
-{% endfor %}
-
-# return either the id of the host or an empty string
-{%- set myid = zookeepers_with_ids.get(grains.id, '').split('+') | first() %}
+{%- if myid_dist|length > 0 %}
+  {%- set myid = myid_dist[0] %}
+{%- else %}
+  {%- set myid = None %}
+{%- endif %}
 
 {%- set zk = {} %}
 {%- do zk.update( { 'uid': uid,
@@ -144,7 +140,7 @@
                     'max_client_cnxns': max_client_cnxns,
                     'myid_path': data_dir + '/myid',
                     'zookeepers' : zookeepers,
-                    'zookeepers_with_ids' : zookeepers_with_ids.values(),
+                    'zookeepers_with_ids' : zookeepers_with_ids,
                     'connection_string' : ','.join(connection_string),
                     'initial_heap_size': initial_heap_size,
                     'max_heap_size': max_heap_size,

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -94,15 +94,9 @@
     {%- if node in (salt['network.get_hostname'](),
                 grains['id'],
                 grains['fqdn'],
-                grains['nodename']) %}
+                grains['nodename']) 
+                or node in minion_ips %}
       {%- do myid_dist.append(node_id)  %}
-    {%- else %}
-      {%- for minion_ip in minion_ips %}
-        {%- if node == minion_ip %}
-          {%- do myid_dist.append(node_id)  %}
-          {% break %}
-        {%- endif %}
-      {%- endfor %}
     {%- endif %}
   {%- endif %}
 {%- endfor %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -77,7 +77,11 @@
   {%- set zookeeper_nodes   = p.get('nodes', []) %}
 {%- else %}
   {%- set force_mine_update = salt['mine.send'](hosts_function) %}
-  {%- set zookeeper_nodes   = salt['mine.get'](hosts_target, hosts_function, targeting_method) %}
+  {%- set zookeepers_mined  = salt['mine.get'](hosts_target,
+                                               hosts_function,
+                                               targeting_method)|
+                                               default({}, true) %}
+  {%- set zookeeper_nodes   = zookeepers_mined.values()|sort %}
 {%- endif %}
 
 {%- for node in zookeeper_nodes %}

--- a/zookeeper/uninstalled.sls
+++ b/zookeeper/uninstalled.sls
@@ -1,0 +1,25 @@
+{%- from 'zookeeper/settings.sls' import zk with context -%}
+{%- from 'zookeeper/map.jinja' import zookeeper_map with context -%}
+
+zk-directories-removed:
+  file.absent:
+    - names:
+      - /var/run/zookeeper
+      - /var/lib/zookeeper
+      - /var/log/zookeeper
+      - {{ zk.real_home }}
+      - {{ zk.alt_home }}
+      - /etc/init.d/zookeeper
+      - {{ zk.real_config }}
+      - {{ zk.alt_config }}
+      - {{ zk.systemd_unit }}
+      - {{ zookeeper_map.service_script }}
+      
+zookeeper-config-link-remove:
+  alternatives.remove:
+    - path: {{ zk.real_config }}
+
+zookeeper-home-link-remove:
+  alternatives.remove:
+    - name: zookeeper-home-link
+    - path: {{ zk.real_home }}


### PR DESCRIPTION
### What does this PR do?

1. Add a new optional parameter `zookeeper:nodes`.
This parameter can be used instead of targeting method to list all zookeeper nodes because In some cases it isn't convenient to use mine.get and target zookeeper nodes (for example, when you have several salt masters).

2. Add a new state `uninstalled`. It can be used to remove zookeeper when it isn't needed.

3. Remove checks of zookeeper nodes count. Right now if you want to use an even number of zookeeper nodes you will still use an odd number of zookeeper nodes. 
It seems strange to use an even number of zookeeper nodes because the probability of losing a node will increase (the probability of loosing one of four nodes is higher than the probability of loosing one of three nodes). But still it isn't right to limit usage of an even number of nodes. It can be useful to use an even number of nodes in testing purposes, for example.

4. Right now to provide nodes and their ids to the configuration file the garbage string is generated (it is called like this in zoo.conf file). I think that it is better to provide a simple JSON string.

5. Fix bug with alternatives. If you remove your /etc/zookeeper directory and try to install zookeeper one more time it will fail. The problem is that alternatives will be set up, but symlinks will already be gone. That is why /etc/zookeeper/conf will not be created.

6. Remove tar file. After zookeeper installation unneeded tar file will still be presented. This PR will remove unneeded tar file.

Please, tell me if you don't agree with something.