### PR TITLE
Add clusters parameter for multi cluster deployment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -198,11 +198,54 @@ Target only some of Minions with particular Grain using `Compound matcher`_:
 .. _`Glob targeting`: https://docs.saltstack.com/en/latest/topics/targeting/globbing.html#globbing
 .. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/compound.html
 
+``nodes``
+~~~~~~~~~~~~~~~~~~~~
+
+If you want to provide your own list of zookeeper nodes you can use ``nodes`` parameter. In this 
+case targeting method and ``clusters`` parameter will not be used.
+
+As a node identifier you can use hostname, IP address, fqdn, minion id.
+You cannot use an IP address of the proxy server which redirects requests to the zookeeper node.
+You can use hostname of the proxy server which redirects requests to the zookeeper node only if
+zookeeper node has the same hostname as the proxy does.
+
+**Examples**:
+
+IP addresses usage:
+
+.. code:: yaml
+
+  zookeeper:
+    nodes:
+      - 192.168.0.101
+      - 192.168.0.102
+      - 192.168.0.103
+
+Minion id usage:
+
+.. code:: yaml
+
+  zookeeper:
+    nodes:
+      - minion1
+      - minion2
+      - minion3
+
+Mixed usage (IP, minion id, fqdn):
+
+.. code:: yaml
+
+  zookeeper:
+    nodes:
+      - 192.168.0.101
+      - minion2
+      - zookeeper3.mysite.com
+
 ``clusters``
 ~~~~~~~~~~~~~~~~~~~~
 
 In case you need several separate Zookeeper clusters you can use ``zookeeper:clusters`` parameter 
-where you can specify a node list for each of your cluster with the ``nodes`` parameter. 
+where you can specify a node list for each of your cluster. 
 In this case targeting method will not be used.
 
 As a node identifier you can use hostname, IP address, fqdn, minion id.
@@ -228,22 +271,22 @@ IP addresses usage:
         - 192.168.1.102
         - 192.168.1.103
         
-Minion id usage:
+Fqdn usage:
 
 .. code:: yaml
 
   zookeeper:
     clusters:
-      - nodes:
-        - minion1
-        - minion2
-        - minion3
-      - nodes:
-        - minion4
-        - minion5
-        - minion6
+      cluster1:
+        - zookeeper1.cluster1.mysite.com
+        - zookeeper2.cluster1.mysite.com
+        - zookeeper3.cluster1.mysite.com
+      cluster2:
+        - zookeeper1.cluster2.mysite.com
+        - zookeeper2.cluster2.mysite.com
+        - zookeeper3.cluster2.mysite.com
 
-Mixed usage (IP, minion id, fqdn):
+Mixed usage (IP, hostname, fqdn):
 
 .. code:: yaml
 

--- a/README.rst
+++ b/README.rst
@@ -198,16 +198,18 @@ Target only some of Minions with particular Grain using `Compound matcher`_:
 .. _`Glob targeting`: https://docs.saltstack.com/en/latest/topics/targeting/globbing.html#globbing
 .. _`Compound matcher`: https://docs.saltstack.com/en/latest/topics/targeting/compound.html
 
-``nodes``
+``clusters``
 ~~~~~~~~~~~~~~~~~~~~
 
-If you want to provide your own list of zookeeper nodes you can use ``nodes`` parameter. In this 
-case targeting method will not be used.
+In case you need several separate Zookeeper clusters you can use ``zookeeper:clusters`` parameter 
+where you can specify a node list for each of your cluster with the ``nodes`` parameter. 
+In this case targeting method will not be used.
 
 As a node identifier you can use hostname, IP address, fqdn, minion id.
 You cannot use an IP address of the proxy server which redirects requests to the zookeeper node.
 You can use hostname of the proxy server which redirects requests to the zookeeper node only if
 zookeeper node has the same hostname as the proxy does.
+You cannot use the same minion for two different clusters.
 
 **Examples**:
 
@@ -216,31 +218,46 @@ IP addresses usage:
 .. code:: yaml
 
   zookeeper:
-    nodes:
-      - 192.168.0.101
-      - 192.168.0.102
-      - 192.168.0.103
-
+    clusters:
+      - nodes:
+        - 192.168.0.101
+        - 192.168.0.102
+        - 192.168.0.103
+      - nodes:
+        - 192.168.1.101
+        - 192.168.1.102
+        - 192.168.1.103
+        
 Minion id usage:
 
 .. code:: yaml
 
   zookeeper:
-    nodes:
-      - minion1
-      - minion2
-      - minion3
+    clusters:
+      - nodes:
+        - minion1
+        - minion2
+        - minion3
+      - nodes:
+        - minion4
+        - minion5
+        - minion6
 
 Mixed usage (IP, minion id, fqdn):
 
 .. code:: yaml
 
   zookeeper:
-    nodes:
-      - 192.168.0.101
-      - minion2
-      - zookeeper3.mysite.com
-      
+    clusters:
+      - nodes:
+        - 192.168.0.101
+        - minion2
+        - zookeeper3.cluster1.mysite.com
+      - nodes:
+        - 192.168.1.101
+        - minion-hostname5
+        - zookeeper3.cluster2.mysite.com
+
 ``restart_on_config``
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/pillar.example
+++ b/pillar.example
@@ -48,15 +48,22 @@ zookeeper:
 #   config:
 #     bind_address: 0.0.0.0
 
-# If you want to provide your own list of zookeeper nodes you can use zookeeper:nodes parameter. 
+# In case you need several separate Zookeeper clusters you can use `zookeeper:clusters` parameter 
+# where you can specify a node list for each of your cluster with the `nodes` parameter. 
 # In this case targeting method will not be used.
 # As a node identifier you can use hostname, IP address, fqdn, minion id.
 # You cannot use an IP address of the proxy server which redirects requests to the zookeeper node. 
 # You can use hostname of the proxy server which redirects requests to the zookeeper node only if 
 # zookeeper node has the same hostname as the proxy does.
-#
+# You cannot use the same minion for two different clusters.
+# 
 # zookeeper:
-#   nodes:
-#     - 192.168.0.101
-#     - minion2
-#     - zookeeper3.mysite.com
+#   clusters:
+#     - nodes:
+#       - 192.168.0.101
+#       - minion2
+#       - zookeeper3.cluster1.mysite.com
+#     - nodes:
+#       - 192.168.1.101
+#       - minion-hostname5
+#       - zookeeper3.cluster2.mysite.com

--- a/pillar.example
+++ b/pillar.example
@@ -48,8 +48,21 @@ zookeeper:
 #   config:
 #     bind_address: 0.0.0.0
 
+# If you want to provide your own list of zookeeper nodes you can use zookeeper:nodes parameter. 
+# In this case targeting method and `zookeeper:clusters` parameter will not be used. 
+# As a node identifier you can use hostname, IP address, fqdn, minion id.
+# You cannot use an IP address of the proxy server which redirects requests to the zookeeper node. 
+# You can use hostname of the proxy server which redirects requests to the zookeeper node only if 
+# zookeeper node has the same hostname as the proxy does.
+#
+# zookeeper:
+#   nodes:
+#     - 192.168.0.101
+#     - minion2
+#     - zookeeper3.mysite.com
+
 # In case you need several separate Zookeeper clusters you can use `zookeeper:clusters` parameter 
-# where you can specify a node list for each of your cluster with the `nodes` parameter. 
+# where you can specify a node list for each of your cluster. 
 # In this case targeting method will not be used.
 # As a node identifier you can use hostname, IP address, fqdn, minion id.
 # You cannot use an IP address of the proxy server which redirects requests to the zookeeper node. 
@@ -59,11 +72,11 @@ zookeeper:
 # 
 # zookeeper:
 #   clusters:
-#     - nodes:
+#     cluster1:
 #       - 192.168.0.101
 #       - minion2
 #       - zookeeper3.cluster1.mysite.com
-#     - nodes:
+#     cluster2:
 #       - 192.168.1.101
 #       - minion-hostname5
 #       - zookeeper3.cluster2.mysite.com

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -79,7 +79,7 @@
 
 {% if p.get('nodes') %}
   {%- set zookeeper_nodes   = p.get('nodes', []) %}
-{% if p.get('clusters') and cluster_id != None %}
+{% elif p.get('clusters') and cluster_id != None %}
   {%- set zookeeper_nodes   = p.get('clusters').get(cluster_id, []) %}  
 {% elif p.get('clusters') %}
   {%- set zookeeper_nodes_tmp   = [] %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -70,7 +70,7 @@
 {%- set cluster_id     = g.get('cluster_id', p.get('cluster_id', None)) %}
 {%- set zookeepers_with_ids = [] %}
 {%- set zookeepers          = [] %}
-{%- set myid_tmp            = [] %}
+{%- set myid_dist            = [] %}
 {%- set connection_string   = [] %}
 {%- set minion_ids          = [salt['network.get_hostname'](),
                                grains['id'],
@@ -90,7 +90,6 @@
       {%- for node in nodes %}
         {%- if node in minion_ids %}
           {%- do zookeeper_nodes_tmp.append(nodes)  %}
-          {%- do myid_tmp.append(loop.index)  %}
           {%- break %}
         {%- endif %}
       {%- endfor %}
@@ -115,15 +114,13 @@
   {%- do zookeepers_with_ids.append(zookeeper_with_id)  %}
   {%- do connection_string.append( node.encode('ascii') + ':' + port | string() ) %}
   {%- do zookeepers.append( node.encode('ascii') ) %}
-  {%- if myid_tmp|length == 0 %}    
-    {%- if node in minion_ids %}
-      {%- do myid_tmp.append(node_id)  %}
-    {%- endif %}
+  {%- if not myid_dist and node in minion_ids %}    
+    {%- do myid_dist.append(node_id)  %}
   {%- endif %}
 {%- endfor %}
 
-{%- if myid_tmp|length > 0 %}
-  {%- set myid = myid_tmp[0] %}
+{%- if myid_dist|length > 0 %}
+  {%- set myid = myid_dist[0] %}
 {%- else %}
   {%- set myid = None %}
 {%- endif %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -74,7 +74,7 @@
 {%- set minion_ips          = salt['network.ip_addrs']() %}
 
 {% if p.get('nodes') %}
-  {%- set zookeeper_nodes   = p.get('nodes', []) %}
+  {%- set zookeeper_nodes   = g.get('nodes', p.get('nodes', [])) %}
 {%- else %}
   {%- set force_mine_update = salt['mine.send'](hosts_function) %}
   {%- set zookeepers_mined  = salt['mine.get'](hosts_target,

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -77,6 +77,8 @@
                                grains['fqdn'],
                                grains['nodename']] + salt['network.ip_addrs']() %}
 
+{% if p.get('nodes') %}
+  {%- set zookeeper_nodes   = p.get('nodes', []) %}
 {% if p.get('clusters') and cluster_id != None %}
   {%- set zookeeper_nodes   = p.get('clusters').get(cluster_id, []) %}  
 {% elif p.get('clusters') %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -80,22 +80,26 @@
 {% if p.get('nodes') %}
   {%- set zookeeper_nodes   = p.get('nodes', []) %}
 {% elif p.get('clusters') and cluster_id != None %}
-  {%- set zookeeper_nodes   = p.get('clusters').get(cluster_id, []) %}  
+  {%- set zookeeper_nodes   = p.get('clusters').get(cluster_id, []) %}
 {% elif p.get('clusters') %}
   {%- set zookeeper_nodes_tmp   = [] %}
-  {% for cluster, nodes in p.get('clusters').iteritems() %}
-    {%- for node in nodes %}
-      {%- if node in minion_ids %}
-        {%- do zookeeper_nodes_tmp.append(nodes)  %}
-        {%- do myid_tmp.append(loop.index)  %}
+  {%- if p.get('clusters')|length == 1 %}
+    {%- set zookeeper_nodes   = p.get('clusters').values()[0] %}
+  {%- else %}
+    {% for cluster, nodes in p.get('clusters').iteritems() %}
+      {%- for node in nodes %}
+        {%- if node in minion_ids %}
+          {%- do zookeeper_nodes_tmp.append(nodes)  %}
+          {%- do myid_tmp.append(loop.index)  %}
+          {%- break %}
+        {%- endif %}
+      {%- endfor %}
+      {%- if zookeeper_nodes_tmp|length != 0 %} 
         {%- break %}
       {%- endif %}
-    {%- endfor %}
-    {%- if zookeeper_nodes_tmp|length != 0 %} 
-      {%- break %}
-    {%- endif %}
-  {% endfor %}
-  {%- set zookeeper_nodes   = zookeeper_nodes_tmp[0] if zookeeper_nodes_tmp|length !=0 else [] %}  
+    {% endfor %}
+    {%- set zookeeper_nodes   = zookeeper_nodes_tmp[0] if zookeeper_nodes_tmp|length !=0 else [] %}  
+  {%- endif %}
 {%- else %}
   {%- set force_mine_update = salt['mine.send'](hosts_function) %}
   {%- set zookeepers_mined  = salt['mine.get'](hosts_target,


### PR DESCRIPTION
Hello @vutny ,
What do you think about checking `nodes` parameters in grains before pillar? I think that it might be useful if you want to create several different zookeeper clusters. For example, when you have different hdfs shards (like Facebook does for messaging system).