### PR TITLE
Fix zookeeper alternatives

### DIFF
--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -36,6 +36,7 @@ zookeeper-home-link:
   alternatives.install:
     - link: {{ zk.alt_home }}
     - path: {{ zk.real_home }}
+    - onlyif: test -d {{ zk.real_home }} && test ! -L {{ zk.alt_home }}
     - priority: 30
     - require:
       - archive: install-zookeeper

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -27,6 +27,7 @@ zookeeper-config-link:
   alternatives.install:
     - link: {{ zk.alt_config }}
     - path: {{ zk.real_config }}
+    - onlyif: test -d {{ zk.real_config }} && test ! -L {{ zk.alt_config }}
     - priority: 30
   file.symlink:
     - name: {{ zk.alt_config }}


### PR DESCRIPTION
In case when we want to update zookeeper to a newer version it will fail because alternatives are already installed with the same priority.

This PR fixes it by skipping alternatives installation if the one is already installed. (I took this solution from `sun-java-formula`).