### PR TITLE
Remove alternatives to prevent collisions

### DIFF
--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -33,15 +33,8 @@ install-zookeeper:
     - group: root
     
 zookeeper-home-link:
-  alternatives.install:
-    - link: {{ zk.alt_home }}
-    - path: {{ zk.real_home }}
-    - onlyif: test -d {{ zk.real_home }} && test ! -L {{ zk.alt_home }}
-    - priority: 30
-    - require:
-      - archive: install-zookeeper
   file.symlink:
     - name: {{ zk.alt_home }}
     - target: {{ zk.real_home }}
     - require:
-      - alternatives: zookeeper-home-link
+      - archive: install-zookeeper

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -24,17 +24,10 @@ move-zookeeper-dist-conf:
       - file: /etc/zookeeper
 
 zookeeper-config-link:
-  alternatives.install:
-    - link: {{ zk.alt_config }}
-    - path: {{ zk.real_config }}
-    - onlyif: test -d {{ zk.real_config }} && test ! -L {{ zk.alt_config }}
-    - priority: 30
   file.symlink:
     - name: {{ zk.alt_config }}
     - target: {{ zk.real_config }}
-    - require:
-      - alternatives: zookeeper-config-link
-      
+
 zookeeper-config-dir:
   file.symlink:
     - name: {{ zk.real_home }}/conf

--- a/zookeeper/uninstalled.sls
+++ b/zookeeper/uninstalled.sls
@@ -25,16 +25,6 @@ zk-directories-removed:
 zookeeper-reload-systemctl:
   module.run:
     - name: service.systemctl_reload
-    - require:
+    - onchanges:
       - file: zk-directories-removed
 {%- endif %}
-  
-zookeeper-config-link-removed:
-  alternatives.remove:
-    - name: zookeeper-config-link
-    - path: {{ zk.real_config }}
-
-zookeeper-home-link-removed:
-  alternatives.remove:
-    - name: zookeeper-home-link
-    - path: {{ zk.real_home }}


### PR DESCRIPTION
This PR removes alternatives which causes sometimes bugs with alternatives installation or removal. For example, in case when the link was removed, but  the alternative is exists, then the installation will fail. Also, uninstall will fail if alternatives not exist (tried with saltstack v2016.11.4).
Also with this PR systemd will be reloaded only on changes (when services are actually removed).