### PR TITLE
Reload systemd only on changes

### DIFF
--- a/zookeeper/uninstalled.sls
+++ b/zookeeper/uninstalled.sls
@@ -25,7 +25,7 @@ zk-directories-removed:
 zookeeper-reload-systemctl:
   module.run:
     - name: service.systemctl_reload
-    - require:
+    - onchanges:
       - file: zk-directories-removed
 {%- endif %}
   

--- a/zookeeper/uninstalled.sls
+++ b/zookeeper/uninstalled.sls
@@ -26,7 +26,7 @@ zookeeper-reload-systemctl:
   module.run:
     - name: service.systemctl_reload
     - onchanges:
-      - file: zk-directories-removed
+      - file: {{ zk.systemd_unit }}
 {%- endif %}
   
 zookeeper-config-link-removed:


### PR DESCRIPTION
@sroegner , @vutny ,
It is the first PR to reload systemd only when the service is removed for uninstall state.