### PR TITLE
set clientPortAddress when bind_address grain is set

### DIFF
--- a/zookeeper/conf/zoo.cfg
+++ b/zookeeper/conf/zoo.cfg
@@ -39,7 +39,7 @@ autopurge.purgeInterval={{ purge_interval }}
 maxClientCnxns={{ max_client_cnxns }}
 {%- endif %}
 
-{%- if zk.bind_address %}
+{%- if bind_address %}
 clientPortAddress={{ bind_address }}
 {%- endif %}
 

--- a/zookeeper/conf/zoo.cfg
+++ b/zookeeper/conf/zoo.cfg
@@ -39,11 +39,11 @@ autopurge.purgeInterval={{ purge_interval }}
 maxClientCnxns={{ max_client_cnxns }}
 {%- endif %}
 
-{% if zookeepers | length() == 1 -%}
-
+{%- if zk.bind_address %}
 clientPortAddress={{ bind_address }}
+{%- endif %}
 
-{%- else %}
+{%- if zookeepers | length() > 1 %}
 
 {%- for node in zookeepers %}
 server.{{ node.id }}={{ node.address }}:{{ quorum_port }}:{{ election_port }}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -29,7 +29,7 @@
 {%- set restart_on_change = p.get('restart_on_config', 'True') %}
 
 # bind_address is only supported as a grain, because it has to be host-specific
-{%- set bind_address      = gc.get('bind_address', '0.0.0.0') %}
+{%- set bind_address      = gc.get('bind_address', '') %}
 
 {%- set data_dir          = gc.get('data_dir', pc.get('data_dir', '/var/lib/zookeeper/data')) %}
 {%- set port              = gc.get('port', pc.get('port', '2181')) %}


### PR DESCRIPTION
Fixes #50.

* replaced '0.0.0.0' with '', see [ZooKeeper docs](https://zookeeper.apache.org/doc/r3.4.9/zookeeperAdmin.html#sc_advancedConfiguration):

>  clientPortAddress
>
>    New in 3.3.0: the address (ipv4, ipv6 or hostname) to listen for client connections; that is, the address that clients attempt to connect to. This is optional, by default we bind in such a way that any connection to the clientPort for any address/interface/nic on the server will be accepted.
