### PR TITLE
[tests] move vendoring from Travis config to bash script

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -35,7 +35,7 @@ platforms:
 suites:
   - name: default
     provisioner:
-      vendor_path: vendor
+      vendor_path: vendor/sun-java-formula
       state_top:
         base:
           '*':

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,4 @@ language: ruby
 services:
   - docker
 
-before_install:
-  - bundle install
-  - mkdir vendor && cd $_ && ( for i in sun-java; do git clone http://github.com/saltstack-formulas/$i-formula.git; mv $i-formula/$i .; rm -rf $i-formula; done ); cd ..
-
-script: bundle exec kitchen verify
+script: ./test/run.sh

--- a/README.rst
+++ b/README.rst
@@ -345,3 +345,14 @@ Restart the Zookeeper service on configuration change. It is recommended to set 
      restart_on_config: True
 
 .. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et
+
+
+Testing
+=======
+
+Running the tests locally
+
+```
+bundle install
+./tests/run.sh
+```

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
 
-rm -rf vendor
-git clone https://github.com/saltstack-formulas/sun-java-formula vendor
+rm -rf vendor/sun-java-formula
+git clone https://github.com/saltstack-formulas/sun-java-formula vendor/sun-java-formula
 bundle exec kitchen verify

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ev
+
+rm -rf vendor
+git clone https://github.com/saltstack-formulas/sun-java-formula vendor
+bundle exec kitchen verify


### PR DESCRIPTION
Closes #49.

On Travis, `bundle install` is already ran by setting `language: ruby`. 