### PR TITLE
fix for issue #58 - process_control_system does not work

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -30,10 +30,12 @@ zookeeper:
     quorum_port: 2888
     election_port: 3888
   restart_on_config: True
-
-# Use external service management instead init or systemd.
-# process_control_system: supervisor # You can use whatever you want not just Supervisord.
+# Use external service management instead init or systemd. default=False
+# process_control_system: True
+# You can use whatever you want not just Supervisord. default='supervisorctl restart zookeeper'
 # pcs_restart_command: 'supervisorctl restart zookeeper'
+# define service management package installed as dependency. default=supervisor
+# process_control_system: supervisor
 
 # Configure Salt Mine function with parameters used in zookeeper:hosts_function
 #

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -31,8 +31,6 @@ zookeeper-config-dir:
 zookeeper-in-supervisord:
   cmd.run:
     - name: "{{ zk.pcs_restart_command }}"
-    - require:
-      - pkg: {{ zk.process_control_system_pkg }}
     - onchanges:
        - file: {{ zk.real_config }}/zoo.cfg
 

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -24,7 +24,7 @@ zookeeper-config-dir:
     - require:
       - cmd: move-zookeeper-dist-conf
 
-{%- if zk.process_control_system is defined %}
+{%- if zk.process_control_system %}
 
   {%- if zk.restart_on_change %}
 
@@ -32,7 +32,7 @@ zookeeper-in-supervisord:
   cmd.run:
     - name: "{{ zk.pcs_restart_command }}"
     - require:
-      - pkg: {{ zk.process_control_system }}
+      - pkg: {{ zk.process_control_system_pkg }}
     - onchanges:
        - file: {{ zk.real_config }}/zoo.cfg
 

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -28,6 +28,11 @@
 # This tells the state whether or not to restart the service on configuration change
 {%- set restart_on_change = p.get('restart_on_config', 'True') %}
 
+# This settings used if process_control_system set to true
+{%- set process_control_system = p.get('process_control_system', False) %}
+{%- set process_control_system_pkg = p.get('process_control_system_pkg', 'supervisor') %}
+{%- set pcs_restart_command = p.get('pcs_restart_command', 'supervisorctl restart zookeeper') %}
+
 # bind_address is only supported as a grain, because it has to be host-specific
 {%- set bind_address      = gc.get('bind_address', '') %}
 
@@ -161,5 +166,8 @@
                     'jvm_opts': jvm_opts,
                     'log_level': log_level,
                     'systemd_unit': systemd_unit,
+                    'process_control_system': process_control_system,
+                    'process_control_system_pkg': process_control_system_pkg,
+                    'pcs_restart_command': pcs_restart_command,
                     'restart_on_change': restart_on_change,
                   } ) %}

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -30,7 +30,6 @@
 
 # This settings used if process_control_system set to true
 {%- set process_control_system = p.get('process_control_system', False) %}
-{%- set process_control_system_pkg = p.get('process_control_system_pkg', 'supervisor') %}
 {%- set pcs_restart_command = p.get('pcs_restart_command', 'supervisorctl restart zookeeper') %}
 
 # bind_address is only supported as a grain, because it has to be host-specific
@@ -167,7 +166,6 @@
                     'log_level': log_level,
                     'systemd_unit': systemd_unit,
                     'process_control_system': process_control_system,
-                    'process_control_system_pkg': process_control_system_pkg,
                     'pcs_restart_command': pcs_restart_command,
                     'restart_on_change': restart_on_change,
                   } ) %}


### PR DESCRIPTION
Hello,

this is the fix for issue #58.

 ```
Fix: process_control_system
    
    Issue: pillar zk.process_control_system was not passed to /zookeeper/server/init.sls
    
    - Added process_control_system in /zookeeper/settings.sls
    - Added process_control_system package to a seperated pillar zk.process_control_system_pkg
    - Set defaults for process_control_system in /zookeeper/settings.sls
      +{%- set process_control_system = p.get('process_control_system', False) %}
      +{%- set process_control_system_pkg = p.get('process_control_system_pkg', 'supervisor') %}
      +{%- set pcs_restart_command = p.get('pcs_restart_command', 'supervisorctl restart
    
    Description: It is possible now to enable/disable process_control_system via pillar.
    Package and command for process control can be set separately.
```