### PR TITLE
Fix for config dir move issue/missing zk logfiles

### DIFF
--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -7,7 +7,7 @@ include:
 
 move-zookeeper-dist-conf:
   cmd.run:
-    - name: mv {{ zk.real_home }}/conf {{ zk.real_config }}
+    - name: mv {{ zk.real_home }}/conf/* {{ zk.real_config }}/
     - unless: test -L {{ zk.real_home }}/conf
     - require:
       - file: /etc/zookeeper
@@ -21,6 +21,7 @@ zookeeper-config-dir:
   file.symlink:
     - name: {{ zk.real_home }}/conf
     - target: {{ zk.real_config }}
+    - force: True
     - require:
       - cmd: move-zookeeper-dist-conf
 


### PR DESCRIPTION
Hello,
there is an issue that causes that no logfiles for zookeeper is written to /var/log/zookeeper. The main problem is that all default config files moved from {{ zk.real_home }}/conf to {{ zk.real_config }} directory. So that there is another config dir in /usr/lib/zookeeper/conf/conf that contains the required log4j configuration. This merge will make sure that all config files in the same directory.

