### PR TITLE
enable users to install packages from distro channels

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -60,3 +60,30 @@ suites:
             source_md5: e4cf1b1593ca870bf1c7a75188f09678
             config:
               port: 2181
+
+  - name: package
+    provisioner:
+      vendor_path: vendor/sun-java-formula
+      state_top:
+        base:
+          '*':
+            - sun-java
+            - sun-java.env
+            - zookeeper
+            - zookeeper.server
+      pillars:
+        top.sls:
+          base:
+            '*':
+              - zookeeper
+              - sun-java
+        sun-java.sls:
+          java:
+            version_name: jdk1.8.0_131
+            source_url: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
+            source_hash: 62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236
+        zookeeper.sls:
+          zookeeper:
+            distro_install: True
+            config:
+              port: 2181

--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,7 @@ zookeeper:
   hosts_function: network.get_hostname
   hosts_target: 'roles:zookeeper'
   targeting_method: grain # [compound, glob] also supported
+  distro_install: False
   config:
     data_dir: /var/lib/zookeeper/data
     port: 2181

--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -19,6 +19,11 @@ zk-directories:
       - /var/log/zookeeper
 
 install-zookeeper:
+{%- if zk.distro_install %}
+  pkg.installed:
+    - name: zookeeper
+    - version: {{ zk.version }}
+{%- else %}
   archive.extracted:
     - name: {{ zk.prefix }}
     - source: {{ zk.source_url }}
@@ -38,3 +43,5 @@ zookeeper-home-link:
     - target: {{ zk.real_home }}
     - require:
       - archive: install-zookeeper
+
+{%- else %}

--- a/zookeeper/init.sls
+++ b/zookeeper/init.sls
@@ -27,11 +27,11 @@ install-zookeeper:
   archive.extracted:
     - name: {{ zk.prefix }}
     - source: {{ zk.source_url }}
-{%- if zk.source_md5 != "" %}
+  {%- if zk.source_md5 != "" %}
     - source_hash: md5={{ zk.source_md5 }}
-{%- else %}
+  {%- else %}
     - skip_verify: True
-{%- endif %}
+  {%- endif %}
     - archive_format: tar
     - if_missing: {{ zk.real_home }}/lib
     - user: root
@@ -44,4 +44,4 @@ zookeeper-home-link:
     - require:
       - archive: install-zookeeper
 
-{%- else %}
+{%- endif %}

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -58,8 +58,8 @@ zookeeper-env.sh:
       max_perm_size: {{ zk.max_perm_size }}
 
 zookeeper-service:
-{%- if not zk.distro_install %}
-  {%- if grains.get('systemd') %}
+  {%- if not zk.distro_install %}
+    {%- if grains.get('systemd') %}
   # provision systemd service unit
   file.managed:
     - name: {{ zk.systemd_unit }}
@@ -76,7 +76,7 @@ zookeeper-service:
       - file: zookeeper-service
     - watch_in:
       - service: zookeeper-service
-  {%- elif zookeeper_map.service_script %}
+    {%- elif zookeeper_map.service_script %}
   # provision System V init script
   file.managed:
     - name: {{ zookeeper_map.service_script }}
@@ -89,18 +89,18 @@ zookeeper-service:
       alt_home: {{ zk.alt_home }}
     - watch_in:
       - service: zookeeper-service
-  {%- endif %}
-{%- else %}
+    {%- endif %}
+  {%- else %}
   service.running:
     - name: zookeeper
     - enable: True
     - require:
       - file: zookeeper-data-dir
-  {%- if zk.restart_on_change %}
+    {%- if zk.restart_on_change %}
     - watch:
-  {%- endif %}
+    {%- endif %}
       - file: zoo-cfg
       - file: zookeeper-env.sh
 
-{%- endif %}
+  {%- endif %}
 {%- endif %}

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -58,6 +58,7 @@ zookeeper-env.sh:
       max_perm_size: {{ zk.max_perm_size }}
 
 zookeeper-service:
+{%- if not zk.distro_install %}
   {%- if grains.get('systemd') %}
   # provision systemd service unit
   file.managed:
@@ -89,6 +90,7 @@ zookeeper-service:
     - watch_in:
       - service: zookeeper-service
   {%- endif %}
+{%- else %}
   service.running:
     - name: zookeeper
     - enable: True
@@ -100,4 +102,5 @@ zookeeper-service:
       - file: zoo-cfg
       - file: zookeeper-env.sh
 
+{%- endif %}
 {%- endif %}

--- a/zookeeper/server/init.sls
+++ b/zookeeper/server/init.sls
@@ -12,6 +12,7 @@ move-zookeeper-dist-conf:
     - require:
       - file: /etc/zookeeper
 
+{%- if not zk.distro_install %}
 zookeeper-config-link:
   file.symlink:
     - name: {{ zk.alt_config }}
@@ -23,6 +24,7 @@ zookeeper-config-dir:
     - target: {{ zk.real_config }}
     - require:
       - cmd: move-zookeeper-dist-conf
+{%- endif %}
 
 {%- if zk.process_control_system is defined %}
 

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -13,7 +13,7 @@
 {%- set distro_install    = p.get('distro_install', False) %}
 
 {%- set version           = g.get('version', p.get('version', '3.4.6')) %}
-{%- set version_name      = 'zookeeper-' + version %}
+{%- set version_name      = 'zookeeper-' + (version if version is defined else '' ) %}
 {%- set default_url       = 'http://apache.osuosl.org/zookeeper/' + version_name + '/' + version_name + '.tar.gz' %}
 {%- set source_url        = g.get('source_url', p.get('source_url', default_url)) %}
 {%- set default_md5s = {
@@ -131,6 +131,7 @@
 {%- do zk.update( { 'uid': uid,
                     'version' : version,
                     'version_name': version_name,
+                    'distro_install': distro_install,
                     'userhome' : userhome,
                     'source_url': source_url,
                     'source_md5': source_md5,

--- a/zookeeper/settings.sls
+++ b/zookeeper/settings.sls
@@ -10,6 +10,8 @@
 {%- set userhome          = p.get('userhome', '/home/zookeeper') %}
 {%- set prefix            = p.get('prefix', '/usr/lib') %}
 
+{%- set distro_install    = p.get('distro_install', False) %}
+
 {%- set version           = g.get('version', p.get('version', '3.4.6')) %}
 {%- set version_name      = 'zookeeper-' + version %}
 {%- set default_url       = 'http://apache.osuosl.org/zookeeper/' + version_name + '/' + version_name + '.tar.gz' %}


### PR DESCRIPTION
This completely cirumvents the archive.extracted module (and the current
bugs associated with it: https://github.com/saltstack/salt/issues/45893)
it also means that we use upstream's service files, so hopefully, we
just have to ensure the service is running.